### PR TITLE
Adds step for obtaining guest cartId to Magento_AggregatedServices documentation

### DIFF
--- a/AggregatedServices/README.md
+++ b/AggregatedServices/README.md
@@ -5,7 +5,7 @@ Current extension exposes product data to anonymous users. In the default Magent
 1. Copy it under `app/code/Magento` directory
 2. Clear cache
 3. Enable module https://devdocs.magento.com/guides/v2.0/install-gde/install/cli/install-cli-subcommands-enable.html
-4. Obtain a guest cartId by making the following request: POST /rest/V1/guest-carts
+4. Obtain a guest cartId by making the following request: `POST /V1/guest-carts`
 5. Make requests to `GET /V1/guest-aggregated-carts/:cartId` without token as a guest, where ":cartId" is what was obtained in step 4
 6. Pass `productAttributesSearchCriteria` to fetch attributes in the same request
 

--- a/AggregatedServices/README.md
+++ b/AggregatedServices/README.md
@@ -5,8 +5,9 @@ Current extension exposes product data to anonymous users. In the default Magent
 1. Copy it under `app/code/Magento` directory
 2. Clear cache
 3. Enable module https://devdocs.magento.com/guides/v2.0/install-gde/install/cli/install-cli-subcommands-enable.html
-4. Make requests to `GET /V1/guest-aggregated-carts/:cartId` without token as a guest
-5. Pass `productAttributesSearchCriteria` to fetch attributes in the same request
+4. Obtain a guest cartId by making the following request: POST /rest/V1/guest-carts
+5. Make requests to `GET /V1/guest-aggregated-carts/:cartId` without token as a guest, where ":cartId" is what was obtained in step 4
+6. Pass `productAttributesSearchCriteria` to fetch attributes in the same request
 
 # Magento aggregated guest cart sample
 


### PR DESCRIPTION
## Description
Adds step for obtaining guest cartId to Magento_AggregatedServices documentation

## Related Issue
https://github.com/adobe/commerce-cif-magento-extension/issues/6

## Motivation and Context
This makes it possible to test the guest-aggregated-carts example by exposing the REST call that is necessary to obtain the cartId. Without this information in the documentation, users may end up using the quote ID as it has been saved into the DB, which will result in an error.

## How Has This Been Tested?
Basic testing included using the REST call that has been added to documentation to obtain a cartId, and then using that cartId in the guest-aggregated-carts example.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.