### PR TITLE
/rest/V1/guest-aggregated-carts fails with 500 after order is place #12

### DIFF
--- a/AggregatedServices/Model/Service/GetCart.php
+++ b/AggregatedServices/Model/Service/GetCart.php
@@ -143,10 +143,11 @@ class GetCart implements GetCartInterface
 
         $cartDetails = $this->cartRepository->get($cartId);
         $aggregatedCart->setCartDetails($cartDetails);
+        $cartItems = $cartDetails->getItems() ?: [];
 
         // Get parent product SKU for configurable items
         $configurableParentRelations = [];
-        foreach ($cartDetails->getItems() as $cartItem) {
+        foreach ($cartItems as $cartItem) {
             if ($cartItem->getProductType() == 'configurable') {
                 /** @var ConfigurableParentRelationInterface $configurableParentRelation */
                 $configurableParentRelation = $this->configurableParentRelationInterfaceFactory->create();
@@ -175,7 +176,7 @@ class GetCart implements GetCartInterface
 
         // Fetch cart products
         $productSkus = [];
-        foreach ($cartDetails->getItems() as $cartItem) {
+        foreach ($cartItems as $cartItem) {
             $productSkus[] = $cartItem->getSku();
         }
         $productsSearchCriteria = $this->searchCriteriaBuilder


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There should be no 500 error after the fix. However empty cart details will be returned, not 404.

<!--- Describe your changes in detail -->

## Related Issue

https://github.com/adobe/commerce-cif-magento-extension/issues/12
<!--- Every pull request must have a reference to a GitHub or Adobe internal issue. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] I ran all tests locally and they pass.
